### PR TITLE
Adding download_jwst_files.py for automated downloading and folder creation for RW-DDT CIT use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
+# VS Code
+*.code-workspace
+
 # pyenv
 .python-version
 

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ data/
 tests.ipynb
 .DS_Store
 www.stsci.edu/
+.vscode/settings.json

--- a/download_jwst_files.py
+++ b/download_jwst_files.py
@@ -11,7 +11,7 @@ from astroquery.mast import Observations
 
 
 MAX_RETRIES = 3
-UMASK_GROUP_WRITABLE = 0o007
+UMASK_OWNER_RW_GROUP_RX = 0o0027
 
 # Auto-disable colors if stdout is redirected
 USE_COLOR = sys.stdout.isatty()
@@ -50,7 +50,9 @@ def temporary_umask(new_umask):
 
 def make_shared_dir(foldername, output_dir, exist_ok=True, dry_run=False):
     """
-    Create a directory with group-writable permissions (02770 mode).
+    Create a directory with group-readable permissions (02750 mode).
+
+    02750: setgid, owner=rwx, group=rx, others=---
 
     Parameters
     ----------
@@ -73,8 +75,8 @@ def make_shared_dir(foldername, output_dir, exist_ok=True, dry_run=False):
         if dry_run:
             log("[DRY-RUN]", YELLOW, f"Would create: {fullpath}")
         else:
-            with temporary_umask(UMASK_GROUP_WRITABLE):
-                os.makedirs(fullpath, mode=0o2770, exist_ok=exist_ok)
+            with temporary_umask(UMASK_OWNER_RW_GROUP_RX):
+                os.makedirs(fullpath, mode=0o2750, exist_ok=exist_ok)
     return fullpath
 
 
@@ -289,13 +291,8 @@ def main():
 
     # Directory structure
     uncalibrated_dir = make_shared_dir('Uncalibrated', output_dir, dry_run=dry_run)
-    stage1_dir = make_shared_dir('Analysis_A/Quicklook/MAST_Stage1',
+    stage1_dir = make_shared_dir('MAST_Stage1',
                                  output_dir, dry_run=dry_run)
-    make_shared_dir('Analysis_A/DeepDive', output_dir, dry_run=dry_run)
-    make_shared_dir('Analysis_A/FluxCal', output_dir, dry_run=dry_run)
-    make_shared_dir('Analysis_A/notebooks', output_dir, dry_run=dry_run)
-    make_shared_dir('Analysis_B/DeepDive', output_dir, dry_run=dry_run)
-    make_shared_dir('Analysis_B/notebooks', output_dir, dry_run=dry_run)
 
     all_downloads_succeeded = True
     for obs_id in observation_ids:

--- a/download_jwst_files.py
+++ b/download_jwst_files.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import argparse
+import requests
+import xml.etree.ElementTree as ET
+from contextlib import contextmanager
+from astroquery.mast import Observations
+
+
+MAX_RETRIES = 3
+UMASK_GROUP_WRITABLE = 0o007
+
+# Auto-disable colors if stdout is redirected
+USE_COLOR = sys.stdout.isatty()
+
+
+def color(code):
+    return code if USE_COLOR else ""
+
+
+# ANSI color codes (conditionally applied)
+RESET = color("\033[0m")
+GREEN = color("\033[92m")
+RED = color("\033[91m")
+YELLOW = color("\033[93m")
+CYAN = color("\033[96m")
+
+TAG_WIDTH = 13  # Space reserved for tags like "[DOWNLOADING]"
+
+
+@contextmanager
+def temporary_umask(new_umask):
+    """
+    Context manager to temporarily change the umask.
+
+    Parameters
+    ----------
+    new_umask : int
+        The umask value to set temporarily.
+    """
+    old_umask = os.umask(new_umask)
+    try:
+        yield
+    finally:
+        os.umask(old_umask)
+
+
+def make_shared_dir(foldername, output_dir, exist_ok=True, dry_run=False):
+    """
+    Create a directory with group-writable permissions (02770 mode).
+
+    Parameters
+    ----------
+    foldername : str
+        Directory name relative to output_dir.
+    output_dir : str
+        The base directory path to create the folder inside.
+    exist_ok : bool
+        Whether to suppress error if directory already exists.
+    dry_run : bool
+        If True, directory is not actually created.
+
+    Returns
+    -------
+    str
+        Full path to the created directory.
+    """
+    fullpath = os.path.join(output_dir, foldername)
+    if not os.path.exists(fullpath):
+        if dry_run:
+            log("[DRY-RUN]", YELLOW, f"Would create: {fullpath}")
+        else:
+            with temporary_umask(UMASK_GROUP_WRITABLE):
+                os.makedirs(fullpath, mode=0o2770, exist_ok=exist_ok)
+    return fullpath
+
+
+def log(tag, color_code, message):
+    """
+    Print a color-coded message with a prefixed tag.
+
+    Parameters
+    ----------
+    tag : str
+        Label to prepend, like "[INFO]".
+    color_code : str
+        ANSI color code.
+    message : str
+        The message to print.
+    """
+    padded_tag = f"{color_code}{tag:<{TAG_WIDTH}}{RESET}"
+    print(f"{padded_tag} {message}", flush=True)
+
+
+def query_MAST(proposal_id, observation_id, visit_id, subgroup='UNCAL'):
+    """
+    Query MAST for data products matching given visit/subgroup.
+
+    Parameters
+    ----------
+    proposal_id : str or int
+        JWST proposal number.
+    observation_id : str or int
+        JWST observation number.
+    visit_id : str or int
+        JWST visit number.
+    subgroup : str
+        Product subgroup to retrieve (e.g., 'UNCAL').
+
+    Returns
+    -------
+    astropy.table.Table
+        Filtered product list.
+    """
+    # Normalize ID formats
+    proposal_id = str(proposal_id).zfill(5)
+    observation_id = str(observation_id).zfill(3)
+    visit_id = str(visit_id).zfill(3)
+
+    # Determine calibration level based on subgroup
+    if subgroup in ['UNCAL', 'GS-ACQ1', 'GS-ACQ2', 'GS-FG', 'GS-ID', 'GS-TRACK']:
+        calib_level = [1]
+    elif subgroup in ['CAL', 'CALINTS', 'RATE', 'RATEINTS', 'ANNNN_CRFINTS',
+                      'GS-ACQ1', 'GS-ACQ2', 'GS-FG', 'GS-ID', 'GS-TRACK', 'RAMP']:
+        calib_level = [2]
+    elif subgroup in ['X1DINTS', 'WHTLT']:
+        calib_level = [3]
+    else:
+        raise ValueError(f"Unknown subgroup: {subgroup}")
+
+    obs_id = f'jw{proposal_id}{observation_id}{visit_id}_03101*'
+
+    sci_table = Observations.query_criteria(proposal_id=proposal_id,
+                                            obs_id=obs_id)
+    if len(sci_table) == 0:
+        raise ValueError(f"No data found for proposal {proposal_id}, "
+                         f"observation {observation_id}, visit {visit_id}")
+
+    data_products = Observations.get_product_list(sci_table)
+    table = Observations.filter_products(data_products,
+                                         productSubGroupDescription=subgroup,
+                                         calib_level=calib_level)
+
+    if len(table) == 0:
+        raise ValueError(f"No data found for subgroup {subgroup}, "
+                         f"calib_level {calib_level}")
+
+    if 'dataURI' not in table.colnames:
+        raise ValueError("No dataURI column found. No downloadable files.")
+
+    table.sort('dataURI')
+    return table
+
+
+def download_files(proposal_id, obs_id, visit_id, download_dir,
+                   subgroup='UNCAL', flat=True, verbose=False,
+                   max_retries=MAX_RETRIES, dry_run=False):
+    """
+    Download files from MAST with retries and dry-run option.
+
+    Parameters
+    ----------
+    proposal_id : int
+        JWST proposal ID.
+    obs_id : int
+        Observation ID.
+    visit_id : int
+        Visit ID.
+    download_dir : str
+        Path to download directory.
+    subgroup : str
+        File type, e.g., 'UNCAL', 'RATEINTS'.
+    flat : bool
+        If True, do not preserve folder structure.
+    verbose : bool
+        Print detailed logs if True.
+    max_retries : int
+        Number of retry attempts for failed downloads.
+    dry_run : bool
+        If True, skip actual download.
+
+    Returns
+    -------
+    bool
+        True if all files succeeded, False otherwise.
+    """
+    if verbose:
+        log("[STARTING]", CYAN,
+            f"Downloading {subgroup} files for proposal {proposal_id}, "
+            f"observation {obs_id}, visit {visit_id}")
+
+    table = query_MAST(proposal_id, obs_id, visit_id, subgroup=subgroup)
+
+    if verbose:
+        log("[INFO]", CYAN, f"Scheduling {len(table)} files for download")
+
+    all_success = True
+
+    for product in table:
+        filename = os.path.basename(product["productFilename"])
+
+        if dry_run:
+            log("[DRY-RUN]", YELLOW,
+                f"Would download: {filename} → {download_dir}")
+            continue
+
+        # Retry logic with exponential backoff
+        for attempt in range(1, max_retries + 1):
+            try:
+                manifest = Observations.download_products(
+                    product, download_dir=download_dir, flat=flat)
+                entry = manifest[0]
+                if (entry["Message"] and
+                        entry["Message"].startswith("HTTPError")):
+                    Observations.login()
+                    manifest = Observations.download_products(
+                        product, download_dir=download_dir, flat=flat)
+                    entry = manifest[0]
+                if entry["Status"] == "COMPLETE":
+                    break  # success
+                else:
+                    raise Exception(f"Incomplete status: {entry['Status']}")
+            except KeyboardInterrupt:
+                raise
+            except Exception as e:
+                wait_time = 2 ** (attempt - 1)
+                log("[RETRY]", YELLOW,
+                    f"{filename} failed (attempt {attempt}/{max_retries}): {e}")
+                if attempt < max_retries:
+                    time.sleep(wait_time)
+                else:
+                    all_success = False
+                    log("[FAILED]", RED, f"{filename}")
+                    break
+
+    return all_success
+
+
+def main():
+    """
+    Entry point to parse arguments and orchestrate directory setup and downloads.
+    """
+    parser = argparse.ArgumentParser(
+        description="Download JWST _uncal and _rateints files from MAST "
+                    "for a given proposal/visit. "
+                    "Creates organized, group-writable directories.")
+
+    parser.add_argument("planet_name", type=str,
+                        help="Target planet name, e.g., GJ3929b")
+    parser.add_argument("proposal_id", type=int,
+                        help="JWST proposal number (e.g., 9235)")
+    parser.add_argument("observation_ids", type=str,
+                        help="Comma-separated observation IDs (e.g., 1 or 4,5)")
+    parser.add_argument("visit_id", type=int,
+                        help="Visit ID to label output directories")
+    parser.add_argument("--base_dir", default="../JWST/",
+                        help="Root directory under which data is organized")
+    parser.add_argument("-q", "--quiet", action="store_true",
+                        help="Suppress progress output")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show actions without performing them")
+    args = parser.parse_args()
+
+    planet_name = args.planet_name.strip()
+    proposal_id = args.proposal_id
+    observation_ids = [int(x.strip())
+                       for x in args.observation_ids.split(",")]
+    visit_id = args.visit_id
+    base_dir = args.base_dir
+    verbose = not args.quiet
+    dry_run = args.dry_run
+
+    # Fetch visit metadata XML
+    url = f"https://www.stsci.edu/jwst-program-info/visits/?program={proposal_id}&download="
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        log("[ERROR]", RED, f"Failed to fetch program XML: {e}")
+        sys.exit(1)
+    root = ET.fromstring(response.content)
+
+    output_dir = os.path.join(base_dir, planet_name, f"visit{visit_id}")
+    if not dry_run:
+        os.makedirs(output_dir, exist_ok=True)
+
+    # Directory structure
+    uncalibrated_dir = make_shared_dir('Uncalibrated', output_dir, dry_run=dry_run)
+    stage1_dir = make_shared_dir('Analysis_A/Quicklook/MAST_Stage1',
+                                 output_dir, dry_run=dry_run)
+    make_shared_dir('Analysis_A/DeepDive', output_dir, dry_run=dry_run)
+    make_shared_dir('Analysis_A/FluxCal', output_dir, dry_run=dry_run)
+    make_shared_dir('Analysis_A/notebooks', output_dir, dry_run=dry_run)
+    make_shared_dir('Analysis_B/DeepDive', output_dir, dry_run=dry_run)
+    make_shared_dir('Analysis_B/notebooks', output_dir, dry_run=dry_run)
+
+    all_downloads_succeeded = True
+    for obs_id in observation_ids:
+        visit = root.find(f".//visit[@observation='{obs_id}']")
+        if visit is None:
+            raise ValueError(f"Visit with observation={obs_id} not found")
+
+        visit_id = int(visit.attrib['visit'])
+        status = visit.findtext("status", default="N/A")
+        if status != "Executed":
+            raise ValueError(f"Observation {obs_id} is not 'Executed'")
+
+        log("[INFO]", CYAN,
+            f"Processing observation {obs_id} into {output_dir}")
+
+        # Download RATEINTS first (smaller)
+        rateints_success = download_files(proposal_id, obs_id, visit_id,
+                                          stage1_dir, 'RATEINTS',
+                                          verbose=verbose, dry_run=dry_run)
+
+        # Download UNCAL files next
+        uncal_success = download_files(proposal_id, obs_id, visit_id,
+                                       uncalibrated_dir, 'UNCAL',
+                                       verbose=verbose, dry_run=dry_run)
+
+        if rateints_success and uncal_success:
+            log("[SUCCESS]", GREEN,
+                f"All files downloaded for observation {obs_id}")
+        else:
+            log("[WARNING]", RED,
+                f"Some downloads failed for observation {obs_id}")
+            all_downloads_succeeded = False
+
+    if all_downloads_succeeded:
+        log("[DONE]", GREEN, "All downloads complete.")
+    else:
+        log("[DONE]", RED, "Some downloads failed.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/download_jwst_files.py
+++ b/download_jwst_files.py
@@ -48,13 +48,13 @@ def temporary_umask(new_umask):
         os.umask(old_umask)
 
 
-def make_shared_dir(foldername, output_dir, exist_ok=True, dry_run=False, mode=0o2750):
+def make_shared_dir(foldername, output_dir, exist_ok=True, dry_run=False, mode=0o2751):
     """
     Create a directory with specific permissions for owner and group.
 
     Common modes:
-    - 0o2750: setgid, owner=rwx, group=rx, others=---
-    - 0o2770: setgid, owner=rwx, group=rwx, others=---
+    - 0o2751: setgid, owner=rwx, group=rx, others=--x
+    - 0o2771: setgid, owner=rwx, group=rwx, others=--x
 
     Parameters
     ----------
@@ -68,7 +68,7 @@ def make_shared_dir(foldername, output_dir, exist_ok=True, dry_run=False, mode=0
         If True, directory is not actually created.
     mode : int, optional
         Octal permission mode to use when creating the directory.
-        Defaults to 0o2750 (owner rwx, group rx, setgid).
+        Defaults to 0o2751 (owner rwx, group rx, setgid, other x).
 
     Returns
     -------
@@ -79,9 +79,9 @@ def make_shared_dir(foldername, output_dir, exist_ok=True, dry_run=False, mode=0
 
     # Decide umask dynamically based on whether group-write is intended
     if mode & 0o0020:  # Check group write bit
-        desired_umask = 0o0007  # Allow group write
+        desired_umask = 0o0006  # Allow group write; block other r/w but allow other x
     else:
-        desired_umask = 0o0027  # Block group write, all others
+        desired_umask = 0o0026  # Block group write, block rw for others
 
     if not os.path.exists(fullpath):
         if dry_run:
@@ -300,7 +300,7 @@ def main():
     root = ET.fromstring(response.content)
 
     output_dir = os.path.join(base_dir, planet_name, f"visit{visit_id}")
-    make_shared_dir(output_dir, '/', dry_run=dry_run, mode=0o2770)
+    make_shared_dir(output_dir, '/', dry_run=dry_run, mode=0o2771)
 
     # Directory structure
     uncalibrated_dir = make_shared_dir('Uncalibrated', output_dir, dry_run=dry_run)

--- a/download_jwst_files.py
+++ b/download_jwst_files.py
@@ -313,10 +313,28 @@ def main():
         if visit is None:
             raise ValueError(f"Visit with observation={obs_id} not found")
 
-        visit_id = int(visit.attrib['visit'])
-        status = visit.findtext("status", default="N/A")
-        if status != "Executed":
-            raise ValueError(f"Observation {obs_id} is not 'Executed'")
+        visit_id = int(visit.attrib["visit"])
+        status = visit.findtext("status", default="N/A").strip()
+
+        log(
+            "[INFO]",
+            CYAN,
+            (
+                f"Matched observation={obs_id}, visit={visit_id}, "
+                f"status={status!r}, attributes={visit.attrib}"
+            ),
+        )
+
+        if status not in {"Executed", "Archived"}:
+            log(
+                "[WARNING]",
+                YELLOW,
+                (
+                    f"Observation {obs_id}, visit {visit_id} has visit-status "
+                    f"{status!r}; continuing because MAST availability will be "
+                    "checked directly."
+                ),
+            )
 
         log("[INFO]", CYAN,
             f"Processing observation {obs_id} into {output_dir}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = [
   { name = "Mees Fix" },
   { name = "Kyle Conroy" },
   { name = "Leonardo Dos Santos" },
+  { name = "Taylor James Bell" },
 ]
 keywords = ["astronomy", "python"]
 classifiers = ["Programming Language :: Python"]
@@ -18,6 +19,7 @@ dependencies = [
     "crds>=12.1.10",
     "matplotlib>=3.10.3",
     "numpy>=2.2.4",
+    "requests>=2.20.0",
     "scipy>=1.15.2",
     "stistools>=1.4.5",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = [
   { name = "Mees Fix" },
   { name = "Kyle Conroy" },
   { name = "Leonardo Dos Santos" },
+  { name = "Taylor James Bell" },
 ]
 keywords = ["astronomy", "python"]
 classifiers = ["Programming Language :: Python"]
@@ -25,6 +26,7 @@ dependencies = [
     "numpy>=2.2.4",
     "pandas>=2.3.3",
     "Pillow>=11.3.0",
+    "requests>=2.20.0",
     "scipy>=1.15.2",
     "stistools>=1.4.5",
     "xarray>=2025.9.0",

--- a/rocky_worlds_utils/jwst/download_jwst_files.py
+++ b/rocky_worlds_utils/jwst/download_jwst_files.py
@@ -419,6 +419,10 @@ def main():
                         help="Maximum attempts when MAST data are unavailable; "
                              "0 retries indefinitely (default: 0)")
     args = parser.parse_args()
+    if args.dry_run:
+        download_visit(args)
+        return
+
     retry_data_unavailable(
         lambda: download_visit(args),
         retry_seconds=args.retry_seconds,

--- a/rocky_worlds_utils/jwst/download_jwst_files.py
+++ b/rocky_worlds_utils/jwst/download_jwst_files.py
@@ -12,6 +12,7 @@ from astroquery.mast import MastMissions
 
 
 MAX_RETRIES = 3
+DEFAULT_RETRY_SECONDS = 600
 
 # Use the JWST-specific MAST Search API rather than the CAOM-backed
 # multi-mission API.  This makes newly archived JWST products available as
@@ -115,6 +116,60 @@ def log(tag, color_code, message):
     """
     padded_tag = f"{color_code}{tag:<{TAG_WIDTH}}{RESET}"
     print(f"{padded_tag} {message}", flush=True)
+
+
+def positive_integer(value):
+    """Return a positive integer for an argparse option."""
+    integer = int(value)
+    if integer < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return integer
+
+
+def nonnegative_integer(value):
+    """Return a non-negative integer for an argparse option."""
+    integer = int(value)
+    if integer < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    return integer
+
+
+def is_data_unavailable_error(error):
+    """Return whether a MAST query failed only because data are unavailable."""
+    return isinstance(error, ValueError) and str(error).startswith("No data found for ")
+
+
+def retry_data_unavailable(operation, retry_seconds=DEFAULT_RETRY_SECONDS,
+                           max_attempts=0):
+    """Retry an operation while MAST reports that data are not available yet.
+
+    Parameters
+    ----------
+    operation : callable
+        Operation to run.
+    retry_seconds : int
+        Number of seconds to wait between attempts.
+    max_attempts : int
+        Maximum total attempts. Zero retries indefinitely.
+    """
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            return operation()
+        except KeyboardInterrupt:
+            raise
+        except Exception as error:
+            if not is_data_unavailable_error(error):
+                raise
+
+            if max_attempts and attempt >= max_attempts:
+                raise
+
+            log("[RETRY]", YELLOW,
+                f"{error}; retrying in {retry_seconds} seconds "
+                f"(attempt {attempt + 1})")
+            time.sleep(retry_seconds)
 
 
 def query_MAST(proposal_id, observation_id, visit_id, subgroup='UNCAL'):
@@ -249,31 +304,8 @@ def download_files(proposal_id, obs_id, visit_id, download_dir,
     return all_success
 
 
-def main():
-    """
-    Entry point to parse arguments and orchestrate directory setup and downloads.
-    """
-    parser = argparse.ArgumentParser(
-        description="Download JWST _uncal and _rateints files from MAST "
-                    "for a given proposal/visit. "
-                    "Creates organized, group-writable directories.")
-
-    parser.add_argument("planet_name", type=str,
-                        help="Target planet name, e.g., GJ3929b")
-    parser.add_argument("proposal_id", type=int,
-                        help="JWST proposal number (e.g., 9235)")
-    parser.add_argument("observation_ids", type=str,
-                        help="Comma-separated observation IDs (e.g., 1 or 4,5)")
-    parser.add_argument("visit_id", type=int,
-                        help="Visit ID to label output directories")
-    parser.add_argument("--base_dir", default="../JWST/",
-                        help="Root directory under which data is organized")
-    parser.add_argument("-q", "--quiet", action="store_true",
-                        help="Suppress progress output")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Show actions without performing them")
-    args = parser.parse_args()
-
+def download_visit(args):
+    """Download the requested JWST visit using parsed command-line arguments."""
     planet_name = args.planet_name.strip()
     proposal_id = args.proposal_id
     observation_ids = [int(x.strip())
@@ -356,6 +388,42 @@ def main():
     else:
         log("[DONE]", RED, "Some downloads failed.")
         sys.exit(1)
+
+
+def main():
+    """Parse command-line arguments and download the requested JWST visit."""
+    parser = argparse.ArgumentParser(
+        description="Download JWST _uncal and _rateints files from MAST "
+                    "for a given proposal/visit. "
+                    "Creates organized, group-writable directories.")
+
+    parser.add_argument("planet_name", type=str,
+                        help="Target planet name, e.g., GJ3929b")
+    parser.add_argument("proposal_id", type=int,
+                        help="JWST proposal number (e.g., 9235)")
+    parser.add_argument("observation_ids", type=str,
+                        help="Comma-separated observation IDs (e.g., 1 or 4,5)")
+    parser.add_argument("visit_id", type=int,
+                        help="Visit ID to label output directories")
+    parser.add_argument("--base_dir", default="../JWST/",
+                        help="Root directory under which data is organized")
+    parser.add_argument("-q", "--quiet", action="store_true",
+                        help="Suppress progress output")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show actions without performing them")
+    parser.add_argument("--retry-seconds", type=positive_integer,
+                        default=DEFAULT_RETRY_SECONDS,
+                        help="Wait between retries when MAST data are unavailable "
+                             f"(default: {DEFAULT_RETRY_SECONDS})")
+    parser.add_argument("--max-attempts", type=nonnegative_integer, default=0,
+                        help="Maximum attempts when MAST data are unavailable; "
+                             "0 retries indefinitely (default: 0)")
+    args = parser.parse_args()
+    retry_data_unavailable(
+        lambda: download_visit(args),
+        retry_seconds=args.retry_seconds,
+        max_attempts=args.max_attempts,
+    )
 
 
 if __name__ == "__main__":

--- a/rocky_worlds_utils/jwst/download_jwst_files.py
+++ b/rocky_worlds_utils/jwst/download_jwst_files.py
@@ -8,10 +8,16 @@ import argparse
 import requests
 import xml.etree.ElementTree as ET
 from contextlib import contextmanager
-from astroquery.mast import Observations
+from astroquery.mast import MastMissions
 
 
 MAX_RETRIES = 3
+
+# Use the JWST-specific MAST Search API rather than the CAOM-backed
+# multi-mission API.  This makes newly archived JWST products available as
+# soon as they reach the archive and keeps level 2 and level 3 datasets
+# separate.
+jwst_mast = MastMissions(mission="jwst")
 
 # Auto-disable colors if stdout is redirected
 USE_COLOR = sys.stdout.isatty()
@@ -136,38 +142,26 @@ def query_MAST(proposal_id, observation_id, visit_id, subgroup='UNCAL'):
     observation_id = str(observation_id).zfill(3)
     visit_id = str(visit_id).zfill(3)
 
-    # Determine calibration level based on subgroup
-    if subgroup in ['UNCAL', 'GS-ACQ1', 'GS-ACQ2', 'GS-FG', 'GS-ID', 'GS-TRACK']:
-        calib_level = [1]
-    elif subgroup in ['CAL', 'CALINTS', 'RATE', 'RATEINTS', 'ANNNN_CRFINTS',
-                      'GS-ACQ1', 'GS-ACQ2', 'GS-FG', 'GS-ID', 'GS-TRACK', 'RAMP']:
-        calib_level = [2]
-    elif subgroup in ['X1DINTS', 'WHTLT']:
-        calib_level = [3]
-    else:
-        raise ValueError(f"Unknown subgroup: {subgroup}")
-
-    obs_id = f'jw{proposal_id}{observation_id}{visit_id}_03101*'
-
-    sci_table = Observations.query_criteria(proposal_id=proposal_id,
-                                            obs_id=obs_id)
+    sci_table = jwst_mast.query_criteria(program=int(proposal_id),
+                                         observtn=int(observation_id),
+                                         visit=int(visit_id))
     if len(sci_table) == 0:
         raise ValueError(f"No data found for proposal {proposal_id}, "
                          f"observation {observation_id}, visit {visit_id}")
 
-    data_products = Observations.get_product_list(sci_table)
-    table = Observations.filter_products(data_products,
-                                         productSubGroupDescription=subgroup,
-                                         calib_level=calib_level)
+    data_products = jwst_mast.get_product_list(sci_table)
+    file_suffix = f"_{subgroup.lower()}"
+    table = jwst_mast.filter_products(data_products,
+                                      file_suffix=file_suffix,
+                                      extension=".fits")
 
     if len(table) == 0:
-        raise ValueError(f"No data found for subgroup {subgroup}, "
-                         f"calib_level {calib_level}")
+        raise ValueError(f"No data found for subgroup {subgroup}")
 
-    if 'dataURI' not in table.colnames:
-        raise ValueError("No dataURI column found. No downloadable files.")
+    if 'filename' not in table.colnames:
+        raise ValueError("No filename column found. No downloadable files.")
 
-    table.sort('dataURI')
+    table.sort('filename')
     return table
 
 
@@ -216,7 +210,7 @@ def download_files(proposal_id, obs_id, visit_id, download_dir,
     all_success = True
 
     for product in table:
-        filename = os.path.basename(product["productFilename"])
+        filename = os.path.basename(product["filename"])
 
         if dry_run:
             log("[DRY-RUN]", YELLOW,
@@ -226,13 +220,13 @@ def download_files(proposal_id, obs_id, visit_id, download_dir,
         # Retry logic with exponential backoff
         for attempt in range(1, max_retries + 1):
             try:
-                manifest = Observations.download_products(
+                manifest = jwst_mast.download_products(
                     product, download_dir=download_dir, flat=flat)
                 entry = manifest[0]
                 if (entry["Message"] and
                         entry["Message"].startswith("HTTPError")):
-                    Observations.login()
-                    manifest = Observations.download_products(
+                    jwst_mast.login()
+                    manifest = jwst_mast.download_products(
                         product, download_dir=download_dir, flat=flat)
                     entry = manifest[0]
                 if entry["Status"] == "COMPLETE":

--- a/rocky_worlds_utils/tests/test_download_jwst_files.py
+++ b/rocky_worlds_utils/tests/test_download_jwst_files.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock
 
 from astropy.table import Table
+import pytest
 
 from ..jwst import download_jwst_files
 
@@ -25,3 +26,31 @@ def test_query_mast_uses_jwst_mission_fields(monkeypatch):
         products, file_suffix="_uncal", extension=".fits"
     )
     assert result["filename"][0].endswith("_uncal.fits")
+
+
+def test_retry_data_unavailable_retries_only_mast_availability(monkeypatch):
+    """Unavailable MAST data retry the complete operation after a delay."""
+    operation = Mock(side_effect=[
+        ValueError("No data found for proposal 01234, observation 001, visit 001"),
+        "complete",
+    ])
+    sleep = Mock()
+    monkeypatch.setattr(download_jwst_files.time, "sleep", sleep)
+
+    result = download_jwst_files.retry_data_unavailable(
+        operation, retry_seconds=7, max_attempts=2
+    )
+
+    assert result == "complete"
+    assert operation.call_count == 2
+    sleep.assert_called_once_with(7)
+
+
+def test_retry_data_unavailable_stops_on_other_errors():
+    """Unexpected failures are not retried."""
+    operation = Mock(side_effect=RuntimeError("connection failed"))
+
+    with pytest.raises(RuntimeError, match="connection failed"):
+        download_jwst_files.retry_data_unavailable(operation, retry_seconds=1)
+
+    operation.assert_called_once()

--- a/rocky_worlds_utils/tests/test_download_jwst_files.py
+++ b/rocky_worlds_utils/tests/test_download_jwst_files.py
@@ -1,0 +1,27 @@
+"""Tests for the JWST-specific MAST download helper."""
+
+from unittest.mock import Mock
+
+from astropy.table import Table
+
+from ..jwst import download_jwst_files
+
+
+def test_query_mast_uses_jwst_mission_fields(monkeypatch):
+    """The download helper queries the JWST API, not CAOM criteria."""
+    mission = Mock()
+    datasets = Table({"fileSetName": ["jw01234001001_02101_00001"]})
+    products = Table({"filename": ["jw01234001001_02101_00001_nircam_uncal.fits"]})
+    mission.query_criteria.return_value = datasets
+    mission.get_product_list.return_value = products
+    mission.filter_products.return_value = products
+    monkeypatch.setattr(download_jwst_files, "jwst_mast", mission)
+
+    result = download_jwst_files.query_MAST("1234", "1", "1", "UNCAL")
+
+    mission.query_criteria.assert_called_once_with(program=1234, observtn=1, visit=1)
+    mission.get_product_list.assert_called_once_with(datasets)
+    mission.filter_products.assert_called_once_with(
+        products, file_suffix="_uncal", extension=".fits"
+    )
+    assert result["filename"][0].endswith("_uncal.fits")

--- a/rocky_worlds_utils/tests/test_download_jwst_files.py
+++ b/rocky_worlds_utils/tests/test_download_jwst_files.py
@@ -1,5 +1,6 @@
 """Tests for the JWST-specific MAST download helper."""
 
+import sys
 from unittest.mock import Mock
 
 from astropy.table import Table
@@ -54,3 +55,21 @@ def test_retry_data_unavailable_stops_on_other_errors():
         download_jwst_files.retry_data_unavailable(operation, retry_seconds=1)
 
     operation.assert_called_once()
+
+
+def test_dry_run_does_not_enter_data_availability_retry_loop(monkeypatch):
+    """A dry run performs one query rather than sleeping and retrying."""
+    download_visit = Mock()
+    retry = Mock()
+    monkeypatch.setattr(download_jwst_files, "download_visit", download_visit)
+    monkeypatch.setattr(download_jwst_files, "retry_data_unavailable", retry)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["download_jwst_files.py", "GJ3929b", "9235", "1", "1", "--dry-run"],
+    )
+
+    download_jwst_files.main()
+
+    retry.assert_not_called()
+    assert download_visit.call_args.args[0].dry_run


### PR DESCRIPTION
Adds `download_jwst_files.py`, a command-line script to streamline downloading UNCAL and RATEINTS products from MAST for JWST programs.

Highlights:
- Supports multiple observation IDs for a given planet/visit
- Creates standardized, group-writable directory structure
- Implements retry logic (exponential backoff) for flaky downloads
- Includes dry-run mode to preview file operations
- Uses visit metadata XML to check status and assign visit IDs
- Avoids hardcoded internal paths

The script is designed for RW-DDT CIT workflows and supports shared storage setups without manual intervention.

Example Usage:
```
  python download_jwst_files.py GJ3929b 9235 4,5 4 --base_dir ../JWST/
```

This replaces older internal versions with a safer, more flexible tool. Prior commit history containing internal paths was intentionally squashed into this clean commit.