### PR TITLE
New flux integrator for `hst.time_series` module

### DIFF
--- a/rocky_worlds_utils/hst/spectrum.py
+++ b/rocky_worlds_utils/hst/spectrum.py
@@ -457,7 +457,6 @@ def generate_spec_hlsp(
     wavelength,
     flux,
     flux_uncertainty,
-    dq_flag,
     target_name,
     start_mjd,
     end_mjd,
@@ -494,9 +493,6 @@ def generate_spec_hlsp(
 
     flux_uncertainty : ``numpy.ndarray``
         Flux uncertainty array in units of erg/s/cm^2/Angstrom.
-
-    dq_flag : ``numpy.ndarray``
-        Data quality flags array.
 
     target_name : ``str``
         Target name.
@@ -650,8 +646,7 @@ def generate_spec_hlsp(
                 format="D",
                 array=flux_uncertainty,
                 unit="erg/s/cm**2/Angstrom",
-            ),
-            fits.Column(name="DQ", format="D", array=dq_flag),
+            )
         ]
     )
 
@@ -701,10 +696,14 @@ def generate_spec_hlsp(
         hdu_list = [hdu_0, hdu_1]
 
     if filename is None:
+        if len(grating) > 5:
+            grating_str = 'multi'
+        else:
+            grating_str = grating.lower()
         filename = "hlsp_rocky-worlds_hst_{}_{}_{}_v{}_spec.fits".format(
             instrument.lower(),
             (target_name.lower()).replace("-", ""),
-            grating.lower(),
+            grating_str,
             version,
         )
     else:

--- a/rocky_worlds_utils/hst/time_series.py
+++ b/rocky_worlds_utils/hst/time_series.py
@@ -551,11 +551,11 @@ def generate_lc_hlsp(
     # First, we deal with the Primary extension material
 
     # Compile lists of meta data
-    exp_start_list = np.array([d["exp_start"] for d in time_series_dict])[0]
-    exp_end_list = np.array([d["exp_end"] for d in time_series_dict])[0]
+    exp_start_list = np.array([d["exp_start"][0] for d in time_series_dict])
+    exp_end_list = np.array([d["exp_end"][-1] for d in time_series_dict])
     elapsed_time = ((max(exp_end_list) - min(exp_start_list)) * u.d).to(
         u.s).value
-    exposure_time = np.sum(np.array([d["exp_time"] for d in time_series_dict]))
+    exposure_time = sum([d["exp_time"].sum() for d in time_series_dict])
 
     # Instantiate the list of HDUs that will be included in the fits file
     hdu_list = []

--- a/rocky_worlds_utils/hst/time_series.py
+++ b/rocky_worlds_utils/hst/time_series.py
@@ -13,23 +13,21 @@ from astropy.io import fits
 from astropy.stats import poisson_conf_interval
 from astropy.time import Time
 import numpy as np
-from scipy.integrate import simpson
 import os
 
-__all__ = ["integrate_flux", "read_fits", "generate_light_curve", "generate_lc_hlsp"]
+__all__ = ["integrate_flux", "read_fits", "generate_light_curve",
+           "generate_lc_hlsp"]
 
 
 # This function integrates the flux within a wavelength range for given arrays
 # for wavelength and flux
 def integrate_flux(
-    wavelength_range,
-    wavelength_list,
-    flux_list,
-    gross_list,
-    net_list,
-    exposure_time,
-    poisson_interval="sherpagehrels",
-    return_integrated_gross=False,
+        wavelength_range,
+        wavelength_list,
+        flux_list,
+        net_list,
+        exposure_time,
+        poisson_interval="sherpagehrels"
 ):
     """
     Integrate fluxes from HST STIS and COS spectra within a range of
@@ -48,9 +46,6 @@ def integrate_flux(
     flux_list : ``numpy.ndarray``
         Array containing the flux values of the spectrum.
 
-    gross_list : ``numpy.ndarray``
-        Array containing the gross counts of the spectrum.
-
     net_list : ``numpy.ndarray``
         Array containing the net count rates of the spectrum.
 
@@ -64,10 +59,6 @@ def integrate_flux(
         ``astropy.stats.poisson_conf_interval``). Default value is
         ``'sherpagehrels'``.
 
-    return_integrated_gross : ``bool``, optional
-        Sets whether the function returns the integrated gross and error (in
-        counts) in addition to the flux. Default value is ``False``.
-
     Returns
     -------
     integrated_flux : ``float``
@@ -75,19 +66,12 @@ def integrate_flux(
 
     integrated_error : ``float``
         Uncertainty of the integrated flux.
-
-    integrated_gross : ``float``
-        Integrated gross counts. Returned only if ``return_integrated_gross`` is
-        set to ``True``.
-
-    average_gross_error :
-        Uncertainty of the integrated gross counts. Returned only if
-        ``return_integrated_gross`` is set to ``True``.
     """
     # Raise an error if the user-defined wavelength range is outside of the
     # hard boundaries of the wavelength list
-    if max(wavelength_range) > max(wavelength_list) or min(wavelength_range) < min(
-        wavelength_list
+    if max(wavelength_range) > max(wavelength_list) or min(
+            wavelength_range) < min(
+            wavelength_list
     ):
         raise ValueError(
             "Wavelength_range must be within the boundaries of the wavelength_list."
@@ -96,56 +80,60 @@ def integrate_flux(
     # Since the pixels may not range exactly in the interval above,
     # we will need to deal with fractional pixels. But first, let's
     # integrate the pixels that are fully inside the range
+    net_count_list = net_list * exposure_time
+
+    # At first, we integrate the net counts and later convert them into fluxes
+    # using the sensitivity function. We do this because, in order to calculate
+    # uncertainties in the Poisson counting regime, we need to work on count
+    # space first, and then convert to fluxes.
     full_indexes = np.where(
         (wavelength_list > wavelength_range[0])
         & (wavelength_list < wavelength_range[1])
     )[0]
-    full_pixel_flux = simpson(
-        y=flux_list[full_indexes], x=wavelength_list[full_indexes]
-    )
+    full_pixel_net_counts = np.sum(net_count_list[full_indexes])
 
-    # And now we deal with the flux in the fractional pixels
-    index_left = full_indexes[0]
-    index_right = full_indexes[-1]
-    pixel_width_left = wavelength_list[index_left] - wavelength_list[index_left - 1]
-    fraction_left = (
-        1 - (wavelength_range[0] - wavelength_list[index_left - 1]) / pixel_width_left
-    )
-    pixel_width_right = wavelength_list[index_right + 1] - wavelength_list[index_right]
-    fraction_right = (
-        1 - (wavelength_list[index_right + 1] - wavelength_range[1]) / pixel_width_right
-    )
-    fractional_flux_left = flux_list[index_left - 1] * fraction_left
-    fractional_flux_right = flux_list[index_right + 1] * fraction_right
-
-    # There is a bug in stistools that overestimates errors of time-tag split
-    # subexposures. So we will need to calculate them manually here
-    # based on the raw counts in the extracted spectra. Here we go.
-    full_pixel_gross = np.sum(gross_list[full_indexes])
-    fractional_gross_left = gross_list[index_left - 1] * fraction_left
-    fractional_gross_right = gross_list[index_right + 1] * fraction_right
-    integrated_gross = full_pixel_gross + fractional_gross_left + fractional_gross_right
+    # We will need an estimate of the sensitivity later
     sensitivity = flux_list[full_indexes] / net_list[full_indexes]
     mean_sensitivity = np.nanmean(sensitivity)
-    gross_error = (
-        poisson_conf_interval(integrated_gross, interval=poisson_interval)
-        - integrated_gross
+
+    # And now we deal with the net counts in the fractional pixels
+    index_left = full_indexes[0]
+    index_right = full_indexes[-1]
+    pixel_width_left = wavelength_list[index_left] - wavelength_list[
+        index_left - 1]
+    fraction_left = (
+            1 - (wavelength_range[0] - wavelength_list[
+        index_left - 1]) / pixel_width_left
     )
-    # Take the average gross error for simplicity
-    average_gross_error = (-gross_error[0] + gross_error[1]) / 2
-    integrated_error = average_gross_error / exposure_time * mean_sensitivity
+    pixel_width_right = wavelength_list[index_right + 1] - wavelength_list[
+        index_right]
+    fraction_right = (
+            1 - (wavelength_list[index_right + 1] - wavelength_range[
+        1]) / pixel_width_right
+    )
+    fractional_net_count_left = net_count_list[index_left - 1] * fraction_left
+    fractional_net_count_right = (
+            net_count_list[index_right + 1] * fraction_right)
 
-    integrated_flux = full_pixel_flux + fractional_flux_left + fractional_flux_right
+    # Calculate the total net counts
+    integrated_net_count = (
+            full_pixel_net_counts + fractional_net_count_left +
+            fractional_net_count_right)
 
-    if return_integrated_gross is False:
-        return integrated_flux, integrated_error
-    else:
-        return (
-            integrated_flux,
-            integrated_error,
-            integrated_gross,
-            average_gross_error,
-        )
+    # Calculate the Poisson uncertainties
+    net_count_error = (
+            poisson_conf_interval(np.abs(integrated_net_count),
+                                  interval=poisson_interval)
+            - integrated_net_count
+    )
+    # Take the average net count error for simplicity
+    average_net_count_error = (-net_count_error[0] + net_count_error[1]) / 2
+
+    integrated_error = (
+            average_net_count_error / exposure_time * mean_sensitivity)
+    integrated_flux = integrated_net_count / exposure_time * mean_sensitivity
+
+    return integrated_flux, integrated_error
 
 
 # Read the time-series fits file
@@ -190,7 +178,6 @@ def read_fits(dataset, prefix, target_name=None):
         - `error` (flux density error in  erg / s / cm ** 2 / A)
         - `gross_counts` (gross counts)
         - `net` (net count rate in counts / s)
-        - `background` (background count rate in counts)
     """
     x1d_filename = dataset + "_ts_x1d.fits"
     x1d_filepath = os.path.join(prefix, x1d_filename)
@@ -234,7 +221,6 @@ def read_fits(dataset, prefix, target_name=None):
         error_array = np.zeros(ts_data_shape)
         gross_array = np.zeros(ts_data_shape)
         net_array = np.zeros(ts_data_shape)
-        background_array = np.zeros(ts_data_shape)
 
         # Populate arrays
         for i in range(n_subexposures):
@@ -249,7 +235,6 @@ def read_fits(dataset, prefix, target_name=None):
             error_array[i] += data["ERROR"]
             gross_array[i] += data["GROSS"] * x1d_header_i["EXPTIME"]
             net_array[i] += data["NET"]
-            background_array[i] += data["BACKGROUND"] * x1d_header_i["EXPTIME"]
 
     time_series_dict = {
         "proposal_id": proposal_id,
@@ -273,7 +258,6 @@ def read_fits(dataset, prefix, target_name=None):
         "error": error_array,  # erg / s / cm ** 2 / A
         "gross_counts": gross_array,  # counts
         "net": net_array,  # counts / s
-        "background": background_array  # counts
     }
 
     return time_series_dict
@@ -281,14 +265,13 @@ def read_fits(dataset, prefix, target_name=None):
 
 # Calculate light curve
 def generate_light_curve(
-    dataset,
-    prefix,
-    wavelength_range=None,
-    return_integrated_gross=False,
-    period=None,
-    reference_time=None,
-    baseline_flux=None,
-    poisson_interval="sherpagehrels",
+        dataset,
+        prefix,
+        wavelength_range=None,
+        period=None,
+        reference_time=None,
+        baseline_flux=None,
+        poisson_interval="sherpagehrels",
 ):
     """
     Calculate a light curve for a time-series observation.
@@ -305,10 +288,6 @@ def generate_light_curve(
     wavelength_range : array-like
         List, array or tuple of two floats containing the start and end of the
         wavelength range to be integrated.
-
-    return_integrated_gross : ``bool``, optional
-        Sets whether the function returns the integrated gross and error (in
-        counts) in addition to the flux. Default value is ``False``.
 
     period : ``float``, optional
         Revolution period of the light curve in unit of days. If set, then this
@@ -347,14 +326,6 @@ def generate_light_curve(
         Uncertainties of the flux values of the light curve in
          erg / s / cm ** 2. If  `baseline_flux`` is set, flux values are
          normalized to units of ``baseline_flux``.
-
-    gross : ``float``
-        Integrated gross counts. Returned only if ``return_integrated_gross`` is
-        set to ``True``.
-
-    gross_error :
-        Uncertainty of the integrated gross counts. Returned only if
-        ``return_integrated_gross`` is set to ``True``.
     """
     if isinstance(dataset, str):
         n_dataset = 1
@@ -375,20 +346,15 @@ def generate_light_curve(
     time = np.zeros([n_dataset, n_subexposures])
     flux = np.zeros([n_dataset, n_subexposures])
     flux_error = np.zeros([n_dataset, n_subexposures])
-    gross = np.zeros([n_dataset, n_subexposures])
-    gross_error = np.zeros([n_dataset, n_subexposures])
 
     for row in range(n_dataset):
         for col in range(n_subexposures):
             wavelength = time_series_dict[row]["wavelength"][col]
             flux_density = time_series_dict[row]["flux"][col]
-            gross_counts = time_series_dict[row]["gross_counts"][col]
             net = time_series_dict[row]["net"][col]
             current_exp_time = time_series_dict[row]["exp_time"][col]
             int_flux = 0.0
             int_error_squared = 0.0
-            int_gross = 0.0
-            int_gross_err_squared = 0.0
             time[row, col] = time_series_dict[row]["time_stamp"][col]
             for segment in range(n_segments):
                 # Figure out the wavelength range
@@ -399,57 +365,27 @@ def generate_light_curve(
                 else:
                     current_wavelength_range = wavelength_range
                 try:
-                    if return_integrated_gross is False:
-                        current_int_flux, current_int_error = integrate_flux(
-                            current_wavelength_range,
-                            wavelength[segment],
-                            flux_density[segment],
-                            gross_counts[segment],
-                            net[segment],
-                            current_exp_time,
-                            return_integrated_gross=False,
-                            poisson_interval=poisson_interval,
-                        )
-                        current_int_gross = 0.0
-                        current_gross_err = 0.0
-                    else:
-                        (
-                            current_int_flux,
-                            current_int_error,
-                            current_int_gross,
-                            current_gross_err,
-                        ) = integrate_flux(
-                            current_wavelength_range,
-                            wavelength[segment],
-                            flux_density[segment],
-                            gross_counts[segment],
-                            net[segment],
-                            current_exp_time,
-                            return_integrated_gross=True,
-                            poisson_interval=poisson_interval,
-                        )
+                    current_int_flux, current_int_error = integrate_flux(
+                        current_wavelength_range,
+                        wavelength[segment],
+                        flux_density[segment],
+                        net[segment],
+                        current_exp_time,
+                        poisson_interval=poisson_interval,
+                    )
                 except ValueError:
                     current_int_flux = 0.0
                     current_int_error = 0.0
-                    current_int_gross = 0.0
-                    current_gross_err = 0.0
                 int_flux += current_int_flux
-                int_gross += current_int_gross
-                int_error_squared += current_int_error**2
-                int_gross_err_squared += current_gross_err**2
+                int_error_squared += current_int_error ** 2
             int_error = np.sqrt(int_error_squared)
-            int_gross_error = np.sqrt(int_gross_err_squared)
             flux[row, col] = int_flux
             flux_error[row, col] = int_error
-            gross[row, col] = int_gross
-            gross_error[row, col] = int_gross_error
 
     # Flatten the arrays
     time = time.flatten()
     flux = flux.flatten()
     flux_error = flux_error.flatten()
-    gross = gross.flatten()
-    gross_error = gross_error.flatten()
 
     if period is not None and reference_time is not None:
         phase = ((np.copy(time) - reference_time) / period) % 1.0
@@ -461,22 +397,19 @@ def generate_light_curve(
         flux /= baseline_flux
         flux_error /= baseline_flux
 
-    if return_integrated_gross is False:
-        return time, flux, flux_error
-    else:
-        return time, flux, flux_error, gross, gross_error
+    return time, flux, flux_error
 
 
 # Create an HLSP file for a time series
 def generate_lc_hlsp(
-    dataset,
-    prefix,
-    wavelength_ranges,
-    source_doi,
-    output_dir="./",
-    filename=None,
-    feature_names=None,
-    version="1.0",
+        dataset,
+        prefix,
+        wavelength_ranges,
+        source_doi,
+        output_dir="./",
+        filename=None,
+        feature_names=None,
+        version="1.0",
 ):
     """
     Generate a high-level spectral product for a time-series observation. The
@@ -536,7 +469,8 @@ def generate_lc_hlsp(
     # Compile lists of meta data
     exp_start_list = np.array([d["exp_start"] for d in time_series_dict])[0]
     exp_end_list = np.array([d["exp_end"] for d in time_series_dict])[0]
-    elapsed_time = ((max(exp_end_list) - min(exp_start_list)) * u.d).to(u.s).value
+    elapsed_time = ((max(exp_end_list) - min(exp_start_list)) * u.d).to(
+        u.s).value
     exposure_time = np.sum(np.array([d["exp_time"] for d in time_series_dict]))
 
     # Instantiate the list of HDUs that will be included in the fits file
@@ -555,13 +489,16 @@ def generate_lc_hlsp(
         "ISO-8601 date-time end of the observation",
     )
     hdu_0.header["DOI"] = ("10.17909/qsyr-ny68", "Digital Object Identifier")
-    hdu_0.header["HLSPID"] = ("ROCKY-WORLDS", "Identifier of this HLSP collection")
+    hdu_0.header["HLSPID"] = ("ROCKY-WORLDS",
+                              "Identifier of this HLSP collection")
     hdu_0.header["HLSP_PI"] = (
         "Hannah Diamond-Lowe",
         "Principal Investigator of this HLSP collection",
     )
-    hdu_0.header["HLSPLEAD"] = ("Leonardo dos Santos", "Full name of HLSP project lead")
-    hdu_0.header["HLSPNAME"] = ("Rocky Worlds DDT", "Title of this HLSP project")
+    hdu_0.header["HLSPLEAD"] = ("Leonardo dos Santos",
+                                "Full name of HLSP project lead")
+    hdu_0.header["HLSPNAME"] = ("Rocky Worlds DDT",
+                                "Title of this HLSP project")
     hdu_0.header["HLSPTARG"] = (
         time_series_dict[0]["target"],
         "Designation of the target",
@@ -585,13 +522,16 @@ def generate_lc_hlsp(
         "https://creativecommons.org/licenses/by/4.0/",
         "Data license URL",
     )
-    hdu_0.header["MJD-BEG"] = (min(exp_start_list), "Start of the observation in MJD")
-    hdu_0.header["MJD-END"] = (max(exp_end_list), "End of the observation in MJD")
+    hdu_0.header["MJD-BEG"] = (min(exp_start_list),
+                               "Start of the observation in MJD")
+    hdu_0.header["MJD-END"] = (max(exp_end_list),
+                               "End of the observation in MJD")
     hdu_0.header["MJD-MID"] = (
         (max(exp_end_list) + min(exp_start_list)) / 2,
         "Mid-time of the observation in MJD",
     )
-    hdu_0.header["OBSERVAT"] = ("HST", "Observatory used to obtain this observation")
+    hdu_0.header["OBSERVAT"] = ("HST",
+                                "Observatory used to obtain this observation")
     hdu_0.header["PROPOSID"] = (
         time_series_dict[0]["proposal_id"],
         "Observatory program/proposal identifier",
@@ -637,7 +577,8 @@ def generate_lc_hlsp(
                 fits.Column(name="FLUX", format="D", array=flux_array),
                 fits.Column(name="FLUXERROR", format="D", array=error_array),
                 fits.Column(name="COUNTS", format="D", array=gross_array),
-                fits.Column(name="COUNTSERROR", format="D", array=gross_error_array),
+                fits.Column(name="COUNTSERROR", format="D",
+                            array=gross_error_array),
             ]
         )
         if feature_names is not None:
@@ -684,7 +625,8 @@ def generate_lc_hlsp(
             time_series_dict[0]["fppos"],
             "FP-POS used for the exposure",
         )
-        hdu_1.header["RADESYS"] = ("ICRS", "Celestial coordinate reference system")
+        hdu_1.header["RADESYS"] = ("ICRS",
+                                   "Celestial coordinate reference system")
         hdu_1.header["RA_TARG"] = (
             time_series_dict[0]["ra"],
             "Right Ascension coordinate of the target in deg",

--- a/rocky_worlds_utils/hst/time_series.py
+++ b/rocky_worlds_utils/hst/time_series.py
@@ -754,11 +754,11 @@ def generate_lc_hlsp(
 
     # Finally create the corresponding FITS file
     if filename is None:
-        filename = "hlsp_rocky-worlds_hst_{}_{}_{}_visit{}_v{}_lc.fits".format(
+        filename = "hlsp_rocky-worlds_hst_{}_{}-visit{}_{}_v{}_lc.fits".format(
             time_series_dict[0]["instrument"].lower(),
             time_series_dict[0]["target"].lower(),
-            time_series_dict[0]["grating"].lower(),
             visit_number,
+            time_series_dict[0]["grating"].lower(),
             version,
         )
     else:

--- a/rocky_worlds_utils/hst/time_series.py
+++ b/rocky_worlds_utils/hst/time_series.py
@@ -14,6 +14,7 @@ from astropy.stats import poisson_conf_interval
 from astropy.time import Time
 import numpy as np
 import os
+from scipy.integrate import simpson
 
 __all__ = ["integrate_flux", "read_fits", "generate_light_curve",
            "generate_lc_hlsp"]
@@ -27,7 +28,8 @@ def integrate_flux(
         flux_list,
         net_list,
         exposure_time,
-        poisson_interval="sherpagehrels"
+        poisson_interval="sherpagehrels",
+        mask_list=None
 ):
     """
     Integrate fluxes from HST STIS and COS spectra within a range of
@@ -59,6 +61,14 @@ def integrate_flux(
         ``astropy.stats.poisson_conf_interval``). Default value is
         ``'sherpagehrels'``.
 
+    mask_list : ``numpy.ndarray``, optional
+        Array containing the mask to be applied to the spectrum. It must have
+        the same shape as ``flux_list`` and it must contain multiplicative
+        values that represent how much weight should be applied to each pixel
+        of the spectrum. Normally, if one wants to have a binary mask, one would
+        assign values of zeros for fully-masked pixels and ones for non-masked
+        pixels. Default value is ``None`` (no masking).
+
     Returns
     -------
     integrated_flux : ``float``
@@ -66,6 +76,12 @@ def integrate_flux(
 
     integrated_error : ``float``
         Uncertainty of the integrated flux.
+
+    integrated_net : ``float``
+        Integrated net count rate.
+
+    integrated_net_error : ``float``
+        Uncertainty of the integrated net count rate.
     """
     # Raise an error if the user-defined wavelength range is outside of the
     # hard boundaries of the wavelength list
@@ -77,10 +93,13 @@ def integrate_flux(
             "Wavelength_range must be within the boundaries of the wavelength_list."
         )
 
+    if mask_list is None:
+        mask_list = np.ones_like(net_list)
+
     # Since the pixels may not range exactly in the interval above,
     # we will need to deal with fractional pixels. But first, let's
     # integrate the pixels that are fully inside the range
-    net_count_list = net_list * exposure_time
+    net_count_list = net_list * exposure_time * mask_list
 
     # At first, we integrate the net counts and later convert them into fluxes
     # using the sensitivity function. We do this because, in order to calculate
@@ -91,10 +110,6 @@ def integrate_flux(
         & (wavelength_list < wavelength_range[1])
     )[0]
     full_pixel_net_counts = np.sum(net_count_list[full_indexes])
-
-    # We will need an estimate of the sensitivity later
-    sensitivity = flux_list[full_indexes] / net_list[full_indexes]
-    mean_sensitivity = np.nanmean(sensitivity)
 
     # And now we deal with the net counts in the fractional pixels
     index_left = full_indexes[0]
@@ -111,6 +126,8 @@ def integrate_flux(
             1 - (wavelength_list[index_right + 1] - wavelength_range[
         1]) / pixel_width_right
     )
+
+    # Get fractional-pixel net counts
     fractional_net_count_left = net_count_list[index_left - 1] * fraction_left
     fractional_net_count_right = (
             net_count_list[index_right + 1] * fraction_right)
@@ -129,11 +146,24 @@ def integrate_flux(
     # Take the average net count error for simplicity
     average_net_count_error = (-net_count_error[0] + net_count_error[1]) / 2
 
+    # Convert net counts to net count rates
+    integrated_net = integrated_net_count / exposure_time
+    integrated_net_error = average_net_count_error / exposure_time
+
+    sensitivity = flux_list[full_indexes] / net_list[full_indexes]
+    mean_sensitivity = np.nanmean(sensitivity)
+
+    # If mean sensitivity is NaN, it's probably because there were no net counts
+    # registered, so flux should be zero anyway
+    if np.isnan(mean_sensitivity):
+        mean_sensitivity = 0
+
     integrated_error = (
             average_net_count_error / exposure_time * mean_sensitivity)
-    integrated_flux = integrated_net_count / exposure_time * mean_sensitivity
+    integrated_flux = integrated_net * mean_sensitivity
 
-    return integrated_flux, integrated_error
+    return (integrated_flux, integrated_error, integrated_net,
+            integrated_net_error)
 
 
 # Read the time-series fits file
@@ -271,6 +301,7 @@ def generate_light_curve(
         period=None,
         reference_time=None,
         baseline_flux=None,
+        mask_ranges=None,
         poisson_interval="sherpagehrels",
 ):
     """
@@ -326,6 +357,12 @@ def generate_light_curve(
         Uncertainties of the flux values of the light curve in
          erg / s / cm ** 2. If  `baseline_flux`` is set, flux values are
          normalized to units of ``baseline_flux``.
+
+    net : ``numpy.ndarray``
+        Net count rate of the light curve in counts / s.
+
+    net_error : ``numpy.ndarray``
+        Uncertainties of the net count rate of the light curve in counts / s.
     """
     if isinstance(dataset, str):
         n_dataset = 1
@@ -346,15 +383,39 @@ def generate_light_curve(
     time = np.zeros([n_dataset, n_subexposures])
     flux = np.zeros([n_dataset, n_subexposures])
     flux_error = np.zeros([n_dataset, n_subexposures])
+    net = np.zeros([n_dataset, n_subexposures])
+    net_error = np.zeros([n_dataset, n_subexposures])
 
     for row in range(n_dataset):
         for col in range(n_subexposures):
             wavelength = time_series_dict[row]["wavelength"][col]
             flux_density = time_series_dict[row]["flux"][col]
-            net = time_series_dict[row]["net"][col]
+            net_rate = time_series_dict[row]["net"][col]
             current_exp_time = time_series_dict[row]["exp_time"][col]
+
+            # Deal with masking wavelength ranges
+            mask_array = np.ones_like(flux_density)
+            if mask_ranges is None:
+                pass
+            else:
+                # Parse the mask_ranges object
+                mask_ranges = np.array(mask_ranges)
+                mask_ranges_shape = mask_ranges.shape
+                if len(mask_ranges_shape) < 2:
+                    mask_ranges = np.array([mask_ranges,])
+                else:
+                    pass
+
+                # Assign zeros to wavelength ranges that the user chose
+                for mask_range in mask_ranges:
+                    mask_array[(wavelength > mask_range[0]) &
+                               (wavelength < mask_range[1])] = 0
+
+            # Start integrating fluxes
             int_flux = 0.0
             int_error_squared = 0.0
+            int_net = 0.0
+            int_net_error_squared = 0.0
             time[row, col] = time_series_dict[row]["time_stamp"][col]
             for segment in range(n_segments):
                 # Figure out the wavelength range
@@ -365,27 +426,40 @@ def generate_light_curve(
                 else:
                     current_wavelength_range = wavelength_range
                 try:
-                    current_int_flux, current_int_error = integrate_flux(
+                    (current_int_flux,
+                     current_int_error,
+                     current_int_net,
+                     current_int_net_error) = integrate_flux(
                         current_wavelength_range,
                         wavelength[segment],
                         flux_density[segment],
-                        net[segment],
+                        net_rate[segment],
                         current_exp_time,
                         poisson_interval=poisson_interval,
+                        mask_list=mask_array[segment]
                     )
                 except ValueError:
                     current_int_flux = 0.0
                     current_int_error = 0.0
+                    current_int_net = 0.0
+                    current_int_net_error = 0.0
                 int_flux += current_int_flux
                 int_error_squared += current_int_error ** 2
+                int_net += current_int_net
+                int_net_error_squared += current_int_net_error ** 2
             int_error = np.sqrt(int_error_squared)
+            int_net_error = np.sqrt(int_net_error_squared)
             flux[row, col] = int_flux
             flux_error[row, col] = int_error
+            net[row, col] = int_net
+            net_error[row, col] = int_net_error
 
     # Flatten the arrays
     time = time.flatten()
     flux = flux.flatten()
     flux_error = flux_error.flatten()
+    net = net.flatten()
+    net_error = net_error.flatten()
 
     if period is not None and reference_time is not None:
         phase = ((np.copy(time) - reference_time) / period) % 1.0
@@ -397,7 +471,7 @@ def generate_light_curve(
         flux /= baseline_flux
         flux_error /= baseline_flux
 
-    return time, flux, flux_error
+    return time, flux, flux_error, net, net_error
 
 
 # Create an HLSP file for a time series

--- a/rocky_worlds_utils/hst/time_series.py
+++ b/rocky_worlds_utils/hst/time_series.py
@@ -301,10 +301,13 @@ def generate_light_curve(
         reference_time=None,
         baseline_flux=None,
         mask_ranges=None,
-        poisson_interval="sherpagehrels",
+        poisson_interval="sherpagehrels"
 ):
     """
-    Calculate a light curve for a time-series observation.
+    Calculate a light curve for a time-series observation. Each row of the
+    returned arrays will correspond to a dataset in ``datasets``. It may
+    populate the arrays with ``np.nan`` when there is a non-homogeneous number
+    of subexposures in the time series.
 
     Parameters
     ----------
@@ -380,17 +383,23 @@ def generate_light_curve(
         raise TypeError("Dataset must be a string or a list.")
 
     n_segments = time_series_dict[0]["n_detector_segments"]
-    n_subexposures = len(time_series_dict[0]["time_stamp"])
+
+    # The number of subexposures per exposure can be variable when the temporal
+    # resolution of the time series is fixes, so we set it to the maximum number
+    # of subexposures in the time series
+    max_n_subexposures = max([len(tsd["time_stamp"]) for tsd in time_series_dict])
 
     # We are going to integrate fluxes within the wavelength range for each
-    # segment, each subexposure, and each dataset
-    time = np.zeros([n_dataset, n_subexposures])
-    flux = np.zeros([n_dataset, n_subexposures])
-    flux_error = np.zeros([n_dataset, n_subexposures])
-    net = np.zeros([n_dataset, n_subexposures])
-    net_error = np.zeros([n_dataset, n_subexposures])
+    # segment, each subexposure, and each dataset. We instantiate the arrays
+    # full of NaNs
+    time = np.full([n_dataset, max_n_subexposures], np.nan)
+    flux = np.full([n_dataset, max_n_subexposures], np.nan)
+    flux_error = np.full([n_dataset, max_n_subexposures], np.nan)
+    net = np.full([n_dataset, max_n_subexposures], np.nan)
+    net_error = np.full([n_dataset, max_n_subexposures], np.nan)
 
     for row in range(n_dataset):
+        n_subexposures = len(time_series_dict[row]["time_stamp"])
         for col in range(n_subexposures):
             wavelength = time_series_dict[row]["wavelength"][col]
             flux_density = time_series_dict[row]["flux"][col]
@@ -458,13 +467,6 @@ def generate_light_curve(
             net[row, col] = int_net
             net_error[row, col] = int_net_error
 
-    # Flatten the arrays
-    time = time.flatten()
-    flux = flux.flatten()
-    flux_error = flux_error.flatten()
-    net = net.flatten()
-    net_error = net_error.flatten()
-
     if period is not None and reference_time is not None:
         phase = ((np.copy(time) - reference_time) / period) % 1.0
         # Center around 0
@@ -486,6 +488,7 @@ def generate_lc_hlsp(
         source_doi,
         mask_ranges=None,
         output_dir="./",
+        visit_number='auto',
         filename=None,
         feature_names=None,
         version="1.0",
@@ -520,9 +523,14 @@ def generate_lc_hlsp(
     output_dir : ``str``
         Path to output directory.
 
+    visit_number : ``str``, optional
+        Sets the visit number that will define the filename. If set to
+        ``'auto'``, will try to parse the visit number from the dataset strings.
+        Default is ``'auto'``.
+
     filename : ``str``, optional
         Output filename. If ``None``, then the output filename will be
-        ``hlsp_rocky-worlds_hst_[instrument]_[target]_[grating]_v[version]_lc.fits``.
+        ``hlsp_rocky-worlds_hst_[instrument]_[target]_[grating]_visit[visit_number]_v[version]_lc.fits``.
         Default is ``None``.
 
     feature_names : ``str`` or ``list``, optional
@@ -544,7 +552,7 @@ def generate_lc_hlsp(
             read_fits(dataset, prefix),
         ]
     elif isinstance(dataset, list):
-        time_series_dict = [read_fits(dataset, prefix) for dataset in dataset]
+        time_series_dict = [read_fits(ds, prefix) for ds in dataset]
     else:
         raise TypeError("Dataset must be a string or a list.")
 
@@ -654,15 +662,28 @@ def generate_lc_hlsp(
             )
         )
 
+        time_series_shape = np.shape(time_array)
+        n_subexposures = time_series_shape[1]
+        format_string = str(n_subexposures) + "D"
+
+        # Set units
+        time_unit = 'MJD'
+        flux_unit = str(u.erg / (u.s * u.cm ** 2 * u.AA))
+        net_unit = 'count / s'
+
         # Set the light curve meta data
         hdu_1 = fits.BinTableHDU.from_columns(
             [
-                fits.Column(name="TIME", format="D", array=time_array),
-                fits.Column(name="FLUX", format="D", array=flux_array),
-                fits.Column(name="FLUXERROR", format="D", array=error_array),
-                fits.Column(name="NET", format="D", array=net_array),
-                fits.Column(name="NETERROR", format="D",
-                            array=net_error_array),
+                fits.Column(name="TIME", format=format_string,
+                            array=time_array, unit=time_unit),
+                fits.Column(name="FLUX", format=format_string,
+                            array=flux_array, unit=flux_unit),
+                fits.Column(name="FLUXERROR", format=format_string,
+                            array=error_array, unit=flux_unit),
+                fits.Column(name="NET", format=format_string, array=net_array,
+                            unit=net_unit),
+                fits.Column(name="NETERROR", format=format_string,
+                            array=net_error_array, unit=net_unit),
             ]
         )
         if feature_names is not None:
@@ -719,12 +740,25 @@ def generate_lc_hlsp(
         # Add the data HDU to the list
         hdu_list.append(hdu_1)
 
+    if visit_number == 'auto':
+        # Try to parse visit number from the dataset strings
+        visit_strings = np.array([ds[4:6] for ds in dataset])
+        unique_strings = np.unique(visit_strings)
+        n_unique_strings = len(unique_strings)
+        if n_unique_strings == 1:
+            visit_number = unique_strings[0]
+        else:
+            visit_number = '+'.join(unique_strings)
+    else:
+        pass
+
     # Finally create the corresponding FITS file
     if filename is None:
-        filename = "hlsp_rocky-worlds_hst_{}_{}_{}_v{}_lc.fits".format(
+        filename = "hlsp_rocky-worlds_hst_{}_{}_{}_visit{}_v{}_lc.fits".format(
             time_series_dict[0]["instrument"].lower(),
             time_series_dict[0]["target"].lower(),
             time_series_dict[0]["grating"].lower(),
+            visit_number,
             version,
         )
     else:

--- a/rocky_worlds_utils/hst/time_series.py
+++ b/rocky_worlds_utils/hst/time_series.py
@@ -14,7 +14,6 @@ from astropy.stats import poisson_conf_interval
 from astropy.time import Time
 import numpy as np
 import os
-from scipy.integrate import simpson
 
 __all__ = ["integrate_flux", "read_fits", "generate_light_curve",
            "generate_lc_hlsp"]
@@ -334,6 +333,11 @@ def generate_light_curve(
         the returned fluxes are in units of the baseline flux. Default is
         ``None`` (no normalization).
 
+    mask_ranges : array-like, optional
+        List, array or tuple of shape (N, 2) containing the start and end of the
+        wavelength range to be masked out of integration. N is the number of
+        ranges to be masked. Default is ``None`` (no masking).
+
     poisson_interval : ``str``, optional
         Poisson confidence interval to use in calculation of errors. The options
         are ``‘root-n’``, ``’root-n-0’``, ``’pearson’``, ``’sherpagehrels’, and
@@ -480,6 +484,7 @@ def generate_lc_hlsp(
         prefix,
         wavelength_ranges,
         source_doi,
+        mask_ranges=None,
         output_dir="./",
         filename=None,
         feature_names=None,
@@ -506,6 +511,11 @@ def generate_lc_hlsp(
 
     source_doi : ``str``
         Source DOI of the observation.
+
+    mask_ranges : array-like, optional
+        List, array or tuple of shape (N, 2) containing the start and end of the
+        wavelength range to be masked out of integration. N is the number of
+        ranges to be masked. Default is ``None`` (no masking).
 
     output_dir : ``str``
         Path to output directory.
@@ -638,9 +648,9 @@ def generate_lc_hlsp(
             wavelength_range = wavelength_ranges
 
         # Calculate light curve
-        time_array, flux_array, error_array, gross_array, gross_error_array = (
+        time_array, flux_array, error_array, net_array, net_error_array = (
             generate_light_curve(
-                dataset, prefix, wavelength_range, return_integrated_gross=True
+                dataset, prefix, wavelength_range, mask_ranges=mask_ranges,
             )
         )
 
@@ -650,9 +660,9 @@ def generate_lc_hlsp(
                 fits.Column(name="TIME", format="D", array=time_array),
                 fits.Column(name="FLUX", format="D", array=flux_array),
                 fits.Column(name="FLUXERROR", format="D", array=error_array),
-                fits.Column(name="COUNTS", format="D", array=gross_array),
-                fits.Column(name="COUNTSERROR", format="D",
-                            array=gross_error_array),
+                fits.Column(name="NET", format="D", array=net_array),
+                fits.Column(name="NETERROR", format="D",
+                            array=net_error_array),
             ]
         )
         if feature_names is not None:
@@ -671,7 +681,7 @@ def generate_lc_hlsp(
             (wavelength_range[0]),
             "Wavelength integration start value",
         )
-        hdu_1.header["WAVE_END"] = (
+        hdu_1.header["WAVEND"] = (
             (wavelength_range[1]),
             "Wavelength integration end value",
         )

--- a/rocky_worlds_utils/tests/hst/test_time_series.py
+++ b/rocky_worlds_utils/tests/hst/test_time_series.py
@@ -9,31 +9,17 @@ from rocky_worlds_utils.hst.time_series import integrate_flux, read_fits
 
 @pytest.mark.order(after="test_cos_timetag_split")  # Ensures file to exists first
 @pytest.mark.parametrize(
-    "exp_flux, exp_flux_err, exp_gross, exp_gross_err, return_integrated_gross",
+    "exp_flux, exp_flux_err",
     [
         (
             6.413406112662675e-11,
             1.0756661559158064e-09,
-            None,
-            None,
-            False,
-        ),
-        (
-            6.413406112662675e-11,
-            1.0756661559158064e-09,
-            2364.58349609375,
-            49.63469436620062,
-            True,
         ),
     ],
 )
-def test_integrate_flux(
-    exp_flux,
-    exp_flux_err,
-    exp_gross,
-    exp_gross_err,
-    return_integrated_gross,
-):
+
+
+def test_integrate_flux(exp_flux, exp_flux_err):
     filename = os.path.join(os.getcwd(), "lcil2ajnq_x1d.fits")
     hdu = fits.open(filename)
 
@@ -43,35 +29,16 @@ def test_integrate_flux(
     net = hdu[1].data["NET"].ravel()
     exptime = hdu[1].header["EXPTIME"]
 
-    if return_integrated_gross:
-        result_flux, result_flux_err, result_gross, result_gross_err = integrate_flux(
-            (1600.0, 1700.0),
-            wavelength,
-            flux,
-            gross,
-            net,
-            exptime,
-            return_integrated_gross=return_integrated_gross,
-        )
-        assert (
-            np.isclose(result_flux, exp_flux)
-            & np.isclose(result_flux_err, exp_flux_err)
-            & np.isclose(result_gross, exp_gross)
-            & np.isclose(result_gross_err, exp_gross_err)
-        )
-    else:
-        result_flux, result_flux_err = integrate_flux(
-            (1600.0, 1700.0),
-            wavelength,
-            flux,
-            gross,
-            net,
-            exptime,
-            return_integrated_gross=return_integrated_gross,
-        )
-        assert np.isclose(result_flux, exp_flux) & np.isclose(
-            result_flux_err, exp_flux_err
-        )
+    result_flux, result_flux_err = integrate_flux(
+        (1600.0, 1700.0),
+        wavelength,
+        flux,
+        net,
+        exptime,
+    )
+    assert np.isclose(result_flux, exp_flux) & np.isclose(
+        result_flux_err, exp_flux_err
+    )
 
 
 @pytest.mark.order(

--- a/rocky_worlds_utils/tests/hst/test_time_series.py
+++ b/rocky_worlds_utils/tests/hst/test_time_series.py
@@ -37,7 +37,10 @@ def test_integrate_flux(exp_flux, exp_flux_err, exp_net, exp_net_err):
         net,
         exptime,
     )
-    assert np.isclose(result_flux, exp_flux) & np.isclose(result_flux_err, exp_flux_err) & np.isclose(result_net, exp_net) & np.isclose(result_net_err, exp_net_err)
+    assert (np.isclose(result_flux, exp_flux) &
+            np.isclose(result_flux_err, exp_flux_err) &
+            np.isclose(result_net, exp_net) &
+            np.isclose(result_net_err, exp_net_err))
 
 
 @pytest.mark.order(

--- a/rocky_worlds_utils/tests/hst/test_time_series.py
+++ b/rocky_worlds_utils/tests/hst/test_time_series.py
@@ -9,17 +9,19 @@ from rocky_worlds_utils.hst.time_series import integrate_flux, read_fits
 
 @pytest.mark.order(after="test_cos_timetag_split")  # Ensures file to exists first
 @pytest.mark.parametrize(
-    "exp_flux, exp_flux_err",
+    "exp_flux, exp_flux_err, exp_net, exp_net_err",
     [
         (
             6.413406112662675e-11,
             1.0756661559158064e-09,
+            2551.2771606445312,
+            173.68694554511777,
         ),
     ],
 )
 
 
-def test_integrate_flux(exp_flux, exp_flux_err):
+def test_integrate_flux(exp_flux, exp_flux_err, exp_net, exp_net_err):
     filename = os.path.join(os.getcwd(), "lcil2ajnq_x1d.fits")
     hdu = fits.open(filename)
 
@@ -35,9 +37,7 @@ def test_integrate_flux(exp_flux, exp_flux_err):
         net,
         exptime,
     )
-    assert np.isclose(result_flux, exp_flux) & np.isclose(
-        result_flux_err, exp_flux_err
-    )
+    assert np.isclose(result_flux, exp_flux) & np.isclose(result_flux_err, exp_flux_err) & np.isclose(result_net, exp_net) & np.isclose(result_net_err, exp_net_err)
 
 
 @pytest.mark.order(

--- a/rocky_worlds_utils/tests/hst/test_time_series.py
+++ b/rocky_worlds_utils/tests/hst/test_time_series.py
@@ -25,11 +25,10 @@ def test_integrate_flux(exp_flux, exp_flux_err):
 
     wavelength = hdu[1].data["WAVELENGTH"].ravel()
     flux = hdu[1].data["FLUX"].ravel()
-    gross = hdu[1].data["GROSS"].ravel()
     net = hdu[1].data["NET"].ravel()
     exptime = hdu[1].header["EXPTIME"]
 
-    result_flux, result_flux_err = integrate_flux(
+    result_flux, result_flux_err, result_net, result_net_err = integrate_flux(
         (1600.0, 1700.0),
         wavelength,
         flux,


### PR DESCRIPTION
The new flux integrator of the `hst.time_series` module has the following changes:

- Correctly calculates the uncertainties of fluxes of extremely faint observations dominated by background counts. 
- Adds the option to mask certain wavelength ranges from the flux integrator
- Simplifies usage of its various functions